### PR TITLE
Add arbitrary SDA/SCL pin support for ESP8266.

### DIFF
--- a/src/SparkFunTSL2561.cpp
+++ b/src/SparkFunTSL2561.cpp
@@ -42,6 +42,28 @@ boolean SFE_TSL2561::begin(char i2c_address)
 	return(true);
 }
 
+boolean SFE_TSL2561::begin(int sda, int scl)
+        // Initialize TSL2561 library with default address (0x39)
+	// and set SDA and SCL pins for ESP8266 boards.
+        // Always return true
+{
+        return(begin(TSL2561_ADDR, sda, scl));
+}
+
+boolean SFE_TSL2561::begin(char i2c_address, int sda, int scl)
+	// Initialize TSL2561 library to arbitrary address or:
+	// TSL2561_ADDR_0 (0x29 address with '0' shorted on board)
+	// TSL2561_ADDR   (0x39 default address)
+	// TSL2561_ADDR_1 (0x49 address with '1' shorted on board)
+	// and set SDA and SCL pins for ESP8266 boards.
+        // Always return true
+{
+	_i2c_address = i2c_address;
+        Wire.begin(sda, scl);
+        return(true);
+}
+
+
 
 boolean SFE_TSL2561::setPowerUp(void)
 	// Turn on TSL2561, begin integrations

--- a/src/SparkFunTSL2561.h
+++ b/src/SparkFunTSL2561.h
@@ -34,7 +34,20 @@ class SFE_TSL2561
 			// TSL2561_ADDR   (0x39 default address)
 			// TSL2561_ADDR_1 (0x49 address with '1' shorted on board)
 			// Always returns true
+
+		boolean begin(int sda, int scl);
+			// Initialize TSL2561 library with default address (0x39)
+			// and set SDA and SCL pins for ESP8266 boards
+			// Always return true
 		
+		boolean begin(char i2c_address, int sda, int scl);
+			// Initialize TSL2561 library to arbitrary address or:
+			// TSL2561_ADDR_0 (0x29 address with '0' shorted on board)
+			// TSL2561_ADDR   (0x39 default address)
+			// TSL2561_ADDR_1 (0x49 address with '1' shorted on board)
+			// and set SDA and SCL pins for ESP8266 boards
+			// Always return true
+
 		boolean setPowerUp(void);
 			// Turn on TSL2561, begin integration
 			// Returns true (1) if successful, false (0) if there was an I2C error


### PR DESCRIPTION
The Wire library that come with the ESP8266 package offers the possibility to set SDA and SCL pins to connect I2C devices directly to the ESP8266 chip on arbitrary pins. These commit make the SparkFun_TSL2561_Arduino_Library aware of this feature to use the TSL2561 directly.

SFE_TSL2561 light;
light.begin(D5, D6);
